### PR TITLE
Translate config values

### DIFF
--- a/packages/components/src/LayerDownload/src/Main.js
+++ b/packages/components/src/LayerDownload/src/Main.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react'
+import { useTranslation } from "react-i18next"
 import { Button } from 'primereact/button';
 import { Toast } from 'primereact/toast'
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
@@ -14,17 +15,6 @@ export const actions = {
 }
 */
 
-const defaultExportFormats = [
-  { value: "geojson", title: "GeoJSON", icon: "pi pi-file", tooltip: "Exportar para ficheiro GeoJSON",
-    outputFormat: "application/json" },
-  { value: "gml", title: "GML", icon: "pi pi-file", tooltip: "Exportar para ficheiro GML",
-    outputFormat: "text/xml; subtype=gml/2.1.2" },
-  { value: "shape", title: "ShapeFile", icon: "pi pi-file", tooltip: "Exportar para ficheiro ShapeFile",
-    outputFormat: "SHAPE-ZIP" },
-  { value: "kml", title: "KML", icon: "pi pi-file", tooltip: "Exportar para ficheiro KML",
-    outputFormat: "application/vnd.google-earth.kml+xml" }
-];
-
 export default function Main({ core, config, record }) {
 
   const { viewer, layer, actions, mainMap, models } = config;
@@ -34,6 +24,21 @@ export default function Main({ core, config, record }) {
   const [downloadFormat, setDownloadFormat] = useState(null);
 
   const toast = useRef(null)
+
+  const { t } = useTranslation();
+
+  const defaultExportFormats = [
+    { value: "geojson", title: "GeoJSON", icon: "pi pi-file", tooltip: t("exportToFileFormat", "Exportar para ficheiro GeoJSON", {format: "GeoJSON"}),
+      outputFormat: "application/json" },
+    { value: "gml", title: "GML", icon: "pi pi-file", tooltip: t("exportToFileFormat", "Exportar para ficheiro GeoJSON", {format: "GML"}),
+      outputFormat: "text/xml; subtype=gml/2.1.2" },
+    { value: "shape", title: "ShapeFile", icon: "pi pi-file", tooltip: t("exportToFileFormat", "Exportar para ficheiro GeoJSON", {format: "Shapefile"}),
+      outputFormat: "SHAPE-ZIP" },
+    { value: "kml", title: "KML", icon: "pi pi-file", tooltip: t("exportToFileFormat", "Exportar para ficheiro GeoJSON", {format: "KML"}),
+      outputFormat: "application/vnd.google-earth.kml+xml" }
+  ];
+
+  console.log(defaultExportFormats);
 
   const component_cfg = record.config_json;
 
@@ -257,13 +262,13 @@ export default function Main({ core, config, record }) {
       {showOnPortal(<Toast ref={toast} position="top-right" />)}
       { showDownloadBtn && (
         <div className="p-grid">
-            <div className="p-col-4">Descarregar</div>
+            <div className="p-col-4">{t("download", "Descarregar")}</div>
             <div className="p-col-8">
               { linkDownload &&
                 <Button
                   className="p-button-sm p-mr-2 p-mb-2"
                   icon={(isDownloading && downloadFormat=='link') ? "pi pi-spin pi-spinner" : "pi pi-external-link pi"} 
-                  label={linkDownload.label || "Abrir"}
+                  label={linkDownload.label || t("open", "Abrir")}
                   onClick={e => downloadLink(linkDownload.filename, linkDownload.url)}
                   disabled={isDownloading}
                 />
@@ -272,7 +277,7 @@ export default function Main({ core, config, record }) {
                 <Button
                   className="p-button-sm p-mr-2 p-mb-2"
                   icon={(isDownloading && downloadFormat=='external') ? "pi pi-spin pi-spinner" : "pi pi-external-link pi"} 
-                  label={externalDownload.label || "Abrir"}
+                  label={externalDownload.label || t("open", "Abrir")}
                   onClick={e => window.open(externalDownload.url, "_blank")}
                   disabled={isDownloading}
                 />

--- a/packages/components/src/LayerEdit/src/EditNode.js
+++ b/packages/components/src/LayerEdit/src/EditNode.js
@@ -6,7 +6,8 @@ import { Button } from 'primereact/button';
 import { InputText } from 'primereact/inputtext';
 import { Dropdown } from 'primereact/dropdown';
 import { InputSwitch } from 'primereact/inputswitch';
-//import './style.css';
+
+import { i18n } from '@scalargis/components';
 
 class EditNode extends React.Component {
 
@@ -101,7 +102,7 @@ class EditNode extends React.Component {
             <label className="p-col-12 p-md-4">{this.props.t("title", "Título")}</label>
             <div className="p-col-12 p-md-8">
               <InputText
-                value={edit.title}
+                value={i18n.translateValue(edit.title)}
                 placeholder={this.props.t("title", "Título")}
                 onChange={e => this.editField('title', e.target.value)}
                 onClick={e => e.target.select()}
@@ -266,13 +267,13 @@ class EditNode extends React.Component {
                 </div>
               </div>
               <div className="p-field p-grid">
-                <label className="p-col-12 p-md-4">{this.props.t("outlineWitdh", "Espessura de Rebordo")}</label>
+                <label className="p-col-12 p-md-4">{this.props.t("outlineWidth", "Espessura de Rebordo")}</label>
                 <div className="p-col-12 p-md-8">
                   <InputText
                     type="number"
                     min="0"
                     value={edit.style_stroke_width}
-                    placeholder={this.props.t("outlineWitdh", "Espessura de Rebordo")}
+                    placeholder={this.props.t("outlineWidth", "Espessura de Rebordo")}
                     onChange={e => this.editField('style_stroke_width', e.target.value)}
                   />
                 </div>

--- a/packages/components/src/LayerMetadata/src/ThemeInfo.js
+++ b/packages/components/src/LayerMetadata/src/ThemeInfo.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import i18next from 'i18next';
 
+import { i18n } from '@scalargis/components';
+
 
 const formatMetadataValue = (element) => {
-
-    console.log(element.url);
-    console.log(element.html);
-
     if (element.type === 'html') {
         return <div dangerouslySetInnerHTML={{__html: element.value}} />
     } else if (element.type === 'hyperlink') {
@@ -42,7 +40,7 @@ class ThemeInfo extends React.Component {
       <div>
         <div className="p-grid">
             <div className="p-col-4">{i18next.t("title", "Título")}</div>
-            <div className="p-col-8">{theme.title}</div>
+            <div className="p-col-8">{i18n.translateValue(theme.title)}</div>
         </div>
         { theme.description ?
         <div className="p-grid">

--- a/packages/components/src/LocaleSelector/src/Main.js
+++ b/packages/components/src/LocaleSelector/src/Main.js
@@ -61,7 +61,7 @@ export default function Main({ as, config, actions, record }) {
       <div style={{marginLeft: '20px'}} className='locale-selector'>
         {localesList.map((item, index) => {
           return (
-            <React.Fragment>
+            <React.Fragment key={index}>
               <Button
                 key={item.value} 
                 label={item.label}

--- a/packages/components/src/PopupInfo/src/Main.js
+++ b/packages/components/src/PopupInfo/src/Main.js
@@ -86,7 +86,7 @@ export default function Main({ config, as, core, actions, utils, record }) {
   let header;  
   if (typeof config?.header === 'object') {
     header = config.header["default"] ? config.header["default"] : "";
-    header = config.header[i18n.resolvedLanguage] ? config.header[i18n.resolvedLanguage] : html;
+    header = config.header[i18n.resolvedLanguage] ? config.header[i18n.resolvedLanguage] : header;
   } else {
     header = config?.header ? t(config.header, config.header) : "";
   }

--- a/packages/components/src/TOC/src/Main.js
+++ b/packages/components/src/TOC/src/Main.js
@@ -10,6 +10,8 @@ import { Panel } from 'primereact/panel';
 import { Message } from 'primereact/message';
 import { Toast } from 'primereact/toast';
 import { Toolbar } from 'primereact/toolbar';
+import { translateValue } from '../../utils/i18n';
+
 
 const diffArray = (arr1, arr2) => arr1.concat(arr2)
     .filter(val => !(arr1.includes(val) && arr2.includes(val)));
@@ -236,8 +238,11 @@ class Main extends React.Component {
     let filterRegEx = new RegExp(filter, "i");
     themes.forEach(n => {
       if (filterDone.includes(n.id)) return;
-      if (!filter) n.filtered = false;
-      else n.filtered = filterRegEx.test(n.title) || filterRegEx.test(n.description) ? false : true;
+      if (!filter) {
+        n.filtered = false
+      } else {
+        n.filtered = filterRegEx.test(translateValue(n.title)) || filterRegEx.test(translateValue(n.description)) ? false : true;
+      }
       filterDone.push(n.id);
       if (!n.filtered) {
         let parents = findAllParents(themes, n.id);
@@ -305,19 +310,19 @@ class Main extends React.Component {
         if (res.success) {
           toastEl.show({
             severity: 'success',
-            summary: 'Gravar Sessão',
-            detail: "A sessão foi gravada com sucesso.",
+            summary: this.props.t("saveSession", "Gravar sessão"),
+            detail: this.props.t("saveSessionSuccessMsg", "A sessão foi gravada com sucesso."),
             sticky: false
           });
           this.props.config.dispatch(this.props.actions.viewer_session_saved(res.session));       
         } else {
-          throw new Error('Não foi possível gravar a sessão.');        
+          throw new Error(this.props.t("saveSessionErrorMsg", "Não foi possível gravar a sessão."));        
         }
       }).catch(error => {
         toastEl.show({
           severity: 'error',
-          summary: 'Ocorreu um erro inesperado',
-          detail: "Não foi possível gravar a sessão.",
+          summary: this.props.t("unexpectedError", "Ocorreu um erro inesperado"),
+          detail: this.props.t("saveSessionErrorMsg", "Não foi possível gravar a sessão."),
           sticky: false
         });
         this.props.config.dispatch(this.props.actions.viewer_save_http_error());
@@ -396,17 +401,17 @@ class Main extends React.Component {
           { (!!cookieData && !!config.viewer.allow_user_session) && 
             <Toolbar className="p-mb-2"
               left={(config.viewer.is_session && 
-                <Button label="Sessão" className="p-button-sm p-button-rounded p-button-info" 
-                  icon="pi pi-check" tooltip={"Gravada em " + config.viewer.session.date}  />)} 
+                <Button label={this.props.t("session", "Sessão")} className="p-button-sm p-button-rounded p-button-info" 
+                  icon="pi pi-check" tooltip={this.props.t("sessionSaveInfo", `Gravada em ${config.viewer.session.date}`, {info: config.viewer.session.date} )}  />)} 
               right={ 
               <React.Fragment>
-                {(config.viewer.session && !config.viewer.is_session) && <Button label="Abrir Sessão" 
+                {(config.viewer.session && !config.viewer.is_session) && <Button label={this.props.t("loadSession","Abrir sessão")} 
                   icon="pi pi-folder-open" 
                   className="p-button-text p-button-sm"
                   onClick={e => this.loadSession()}
                   disabled={(config.viewer.save_loading)}
-                  tooltip={"Gravada em " + config.viewer.session.date} />}
-                <Button label="Gravar Sessão"
+                  tooltip={this.props.t("sessionSaveInfo", `Gravada em ${config.viewer.session.date}`, {info: config.viewer.session.date} )} />}
+                <Button label={this.props.t("saveSession", "Gravar sessão")}
                   icon={config.viewer.save_loading ? "pi pi-spin pi-spinner": "pi pi-save"}
                   className="p-button-text p-button-sm"
                   onClick={e => this.saveSession(toastEl)} 
@@ -419,14 +424,14 @@ class Main extends React.Component {
             { component_cfg.show_filter !== false ? (
               <div className="p-inputgroup">
                 <InputText 
-                  placeholder='Filtro...'
+                  placeholder={`${this.props.t('filter', "Filtro")}...`}
                   className="p-inputtext-sm p-mb-2"
                   value={filter}
                   onChange={this.changeFilter.bind(this)}
                 />
                 <Button
                   icon="pi pi-times"
-                  label="Limpar"
+                  label={this.props.t('clear', "Limpar")}
                   className="p-button-sm p-mb-2"
                   onClick={this.clearFilter.bind(this)}
                 />
@@ -436,7 +441,7 @@ class Main extends React.Component {
           ) : (
             <Message
               severity="info"
-              text="Não existem temas. Clique no menu + para adicionar." 
+              text={this.props.t("noTocThemesMsg", "Não existem temas. Clique no menu + para adicionar.")}
             />
           ) }
 

--- a/packages/components/src/TOC/src/TOC/Node.js
+++ b/packages/components/src/TOC/src/TOC/Node.js
@@ -7,6 +7,8 @@ import { Button } from 'primereact/button';
 import DraggableItem from './DraggableItem';
 import Legend from "./Legend";
 
+import { i18n } from '@scalargis/components';
+
 class Node extends React.Component {
 
   state = { detailsOpen: false }
@@ -110,7 +112,7 @@ class Node extends React.Component {
                 <td className={(onScale ? "title" : "title outofscale") + (isGroup ? " title-grp" : "")}>
                   { data.style_color ? <i className='pi pi-square' style={{color: `rgba(${data.style_color})` }} /> : null }
                   <label htmlFor={data.id} className={"label" + (isGroup ? " label-grp" : "") }>
-                    {data.title}
+                    {i18n.translateValue(data.title)}
                   </label>
                   { !data.system && (
                     <div className={"theme-tools" + (detailsOpen ? "" : " hidden") }>

--- a/packages/components/src/utils/i18n.js
+++ b/packages/components/src/utils/i18n.js
@@ -31,3 +31,14 @@ export const loadBackendTranslations = (url, deep=true, overwrite=true, callback
 export const getTranslations = () => {
   return i18next.options.resources;
 }
+
+export const translateValue = (value, defaultString=null, lang=i18next.resolvedLanguage, t=i18next?.t, namespaces=i18next?.options?.ns) => {
+  let translatedValue = defaultString;
+  if (typeof value === 'object') {
+    translatedValue = value["default"] ? value["default"] : "";
+    translatedValue = value[lang] ? value[lang] : translatedValue;
+  } else {
+    translatedValue = value ? (namespaces ? t(value, defaultString, { ns: namespaces }) : t(value, defaultString)) : "";
+  }
+  return translatedValue;
+}

--- a/packages/viewer/src/core/components/MainMenu.js
+++ b/packages/viewer/src/core/components/MainMenu.js
@@ -24,7 +24,7 @@ export default function MainMenu(props) {
             props: { components, history, viewer, dispatch, mainMap, Models: { MapModel, OWSModel, Utils }, auth }
           })}
         </div>
-        <div class="p-mt-auto">
+        <div className="p-mt-auto">
           { core.renderMainMenu({
             selected_menu,
             section: 'bottom',

--- a/packages/viewer/src/core/i18n/translations/en.json
+++ b/packages/viewer/src/core/i18n/translations/en.json
@@ -38,7 +38,7 @@
   "zoomToElement": "Zoom to element",
   "removeElement":"Remove element",
   "exportResults": "Export results",
-  "export": "Exportar",
+  "export": "Export",
   "clearResults": "Clear results",
   "clear": "Clear",
   "selectCRS": "Select a CRS",
@@ -83,7 +83,7 @@
   "clearAll": "Clear all",
   "fillColor": "Fill color",
   "outlineColor": "Outline color",
-  "outlineWidth": "Outline size",
+  "outlineWidth": "Outline width",
   "drawings": "Drawings",
   "noDrawings": "No drawinngs",
   "delete": "Delete",
@@ -173,5 +173,21 @@
   "selectStyle": "Select Style",
   "notDefined": "Not Defined",
 
-  "setTransparency": "Set Transparency"
+  "setTransparency": "Set Transparency",
+
+  "download": "Download",
+  "exportToFileFormat": "Export to {{format}} file",
+  "open": "Open",
+
+  "filter": "Filter",
+
+  "noTocThemesMsg": "There are no themes. Click on the + menu to add them.",
+
+  "session": "Session",
+  "saveSession": "Save session",
+  "saveSessionSuccessMsg": "The session was recorded successfully.",
+  "unexpectedError": "An unexpected error has occurred",
+  "saveSessionErrorMsg": "It was not possible to record the session.",
+  "sessionSaveInfo": "Saved in {{info}}",
+  "loadSession": "Open session"
 }

--- a/packages/viewer/src/core/i18n/translations/es.json
+++ b/packages/viewer/src/core/i18n/translations/es.json
@@ -83,7 +83,7 @@
   "clearAll": "Borrar todos",
   "fillColor": "Color de relleno",
   "outlineColor": "Color del borde",
-  "outlineWitdh": "Ancho del borde",
+  "outlineWidth": "Ancho del borde",
   "drawings": "Dibujos",
   "noDrawings": "No hay dibujos",
   "delete": "Borrar",
@@ -173,5 +173,21 @@
   "selectStyle": "Escolha o Estilo",
   "notDefined": "No Definido",
 
-  "setTransparency": "Definir Transparencia"  
+  "setTransparency": "Definir Transparencia",
+
+  "download": "Descargar",
+  "exportToFileFormat": "exportar a archivo {{format}}",
+  "open": "Abrir",
+
+  "filter": "Filtro",
+
+  "noTocThemesMsg": "No hay capas. Haz clic en el menú + para añadirlos.",
+
+  "session": "Sesión",
+  "saveSession": "Grabar sesión",
+  "saveSessionSuccessMsg": "La sesión ha sido grabada correctamente.",
+  "unexpectedError": "Se ha producido un error inesperado",
+  "saveSessionErrorMsg": "No ha sido posible grabar la sesión.",
+  "sessionSaveInfo": "Grabada en {{info}}",
+  "loadSession": "Cargar sesión"
 }

--- a/packages/viewer/src/core/i18n/translations/pt.json
+++ b/packages/viewer/src/core/i18n/translations/pt.json
@@ -83,7 +83,7 @@
   "clearAll": "Limpar tudo",
   "fillColor": "Côr de preenchimento",
   "outlineColor": "Côr de rebordo",
-  "outlineWitdh": "Espessura de rebordo",
+  "outlineWidth": "Espessura de rebordo",
   "drawings": "Desenhos",
   "noDrawings": "Não existem desenhos",
   "delete": "Eliminar",
@@ -173,5 +173,21 @@
   "selectStyle": "Escolha o Estilo",
   "notDefined": "Não Especificado",
 
-  "setTransparency": "Definir Transparência"
+  "setTransparency": "Definir Transparência",
+
+  "download": "Descarregar",
+  "exportToFileFormat": "Exportar para ficheiro {{format}}",
+  "open": "Abrir",
+
+  "filter": "Filtro",
+
+  "noTocThemesMsg": "Não existem temas. Clique no menu + para adicionar.",
+
+  "session": "Sessão",
+  "saveSession": "Gravar sessão",
+  "saveSessionSuccessMsg": "A sessão foi gravada com sucesso.",
+  "unexpectedError": "Ocorreu um erro inesperado",
+  "saveSessionErrorMsg": "Não foi possível gravar a sessão.",
+  "sessionSaveInfo": "Gravada em {{info}}",
+  "loadSession": "Abrir sessão"
 }

--- a/packages/viewer/src/core/map_control/FeatureInfo.js
+++ b/packages/viewer/src/core/map_control/FeatureInfo.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react'
-import { useTranslation} from "react-i18next"
+import { useTranslation } from "react-i18next"
 import VectorLayer from 'ol/layer/Vector'
 import { Vector } from 'ol/source';
 import OlVectorTileLayer from "ol/layer/VectorTile";
@@ -77,6 +77,7 @@ export default function FeatureInfo({ core, config, actions }) {
             type: 'ol',
             data: serializeFeatures([feature]),
             layer: l ? l.get('title') : '',
+            layerId: l ? l.get('id') : null, 
             feature_tpl: l.get('feature_tpl') ? l.get('feature_tpl') : null
           };
         } else {
@@ -84,7 +85,7 @@ export default function FeatureInfo({ core, config, actions }) {
           Object.keys(feature)
             .filter(k => typeof feature[k] !== 'object')
             .forEach(k => data[k] = feature[k]);
-          return { id: uuidV4(), type: 'object', data, layer: l ? l.get('title') : '' };
+          return { id: uuidV4(), type: 'object', data, layer: l ? l.get('title') : '', "layerId": l ? l.get('id') : null };
         }
       }
     }
@@ -233,7 +234,7 @@ export default function FeatureInfo({ core, config, actions }) {
               acc.push(displayFeature(result, l));
             }          
           } else {
-           acc.push({id: uuidV4(), type: 'text', data: result, layer: l.get('title') || 'teste'});
+           acc.push({id: uuidV4(), type: 'text', data: result, layer: l ? l.get('title') : '', "layerId": l ? l.get('id') : null});
           }
           dispatch(actions.viewer_set_featureinfo(acc));
         });
@@ -294,7 +295,7 @@ export default function FeatureInfo({ core, config, actions }) {
               acc.push(displayFeature(result, l));
             }          
           } else {
-           acc.push({id: uuidV4(), type: 'text', data: result, layer: l.get('title') || 'teste'});
+           acc.push({id: uuidV4(), type: 'text', data: result, layer: l ? l.get('title') : '', "layerId": l ? l.get('id') : null});
           }
           dispatch(actions.viewer_set_featureinfo(acc));
         });


### PR DESCRIPTION
Add support for config values translation. A config value can be an object with values in different languages. As before, it can also be a simple string. Example of a multi language config value:

value: { default: "valor 1", "pt": "valor 1", "en": "value 1"} 
